### PR TITLE
v.1.0.1 stock_summaries API change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Remove `stock_summaries` parameter for `facilityId` based on change to API and 3PL vendor recommendation.
+
 ## 1.0.0
   * Preparing for v1.0.0 release
 

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-3plcentral',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the 3PLCentral Resource (REL) API.',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_3plcentral'],
       install_requires=[
           'backoff==1.8.0',
-          'requests==2.22.0',
-          'singer-python==5.8.1'
+          'requests==2.23.0',
+          'singer-python==5.9.0'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_3plcentral/sync.py
+++ b/tap_3plcentral/sync.py
@@ -375,8 +375,7 @@ def sync(client, config, catalog, state, start_date):
         'stock_summaries': {
             'path': 'inventory/stocksummaries',
             'params': {
-                'pgsiz': 200,
-                'facilityid': facility_id
+                'pgsiz': 200
             },
             'data_key': 'Summaries',
             'id_fields': ['facility_id', 'item_id']


### PR DESCRIPTION
# Description of change
3PL vendor is going to change their API this next week for `stock_summaries` endpoint. This PR removes the `facilityId` parameter from the `stock_summaries` GET request, based on change to API and 3PL vendor recommendation.

# Manual QA steps
Made change. Ran tap for singer-discover, singer-check-tap, and target-stitch (initial load and ongoing incremental load). No issues with API calls or data results returned.
 
# Risks
Low - very minor change. If this change is not made in the next week, anyone using the tap for the `stock_summaries` endpoint will receive tap GET request errors.
 
# Rollback steps
Revert to 1.0.0
